### PR TITLE
Used pytest and mocker to make code cleaner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+py==1.4.34
+pytest==3.1.3
+pytest-mock==1.6.0

--- a/test_async_receive.py
+++ b/test_async_receive.py
@@ -2,12 +2,16 @@
 import asyncio
 import unittest
 from unittest import mock
+
+import pytest as pytest
+
 from async_receive import receive
 
 
 def _run(coro):
     """Run the given coroutine."""
     return asyncio.get_event_loop().run_until_complete(coro)
+
 
 def AsyncMock(*args, **kwargs):
     """Create an async function mock."""
@@ -30,15 +34,25 @@ class TestReceive(unittest.TestCase):
         from async_receive import send_to_client
         send_to_client.mock.assert_called_once_with('PONG', 'data')
 
-    @mock.patch('async_receive.send_to_client', new=AsyncMock())
-    @mock.patch('async_receive.trigger_event',
-                new=AsyncMock(return_value='my response'))
-    def test_message(self):
-        with mock.patch('async_receive.send_to_client', new=AsyncMock()) as send_to_client:
-            with mock.patch('async_receive.trigger_event', new=AsyncMock(return_value='my response')) as trigger_event:
-                _run(receive('MESSAGE', 'data'))
-                trigger_event.mock.assert_called_once_with('message', 'data')
-                send_to_client.mock.assert_called_once_with('MESSAGE', 'my response')
+
+@pytest.fixture
+def send_to_client(mocker):
+    send_to_client_mock = AsyncMock()
+    mocker.patch('async_receive.send_to_client', new=send_to_client_mock)
+    return send_to_client_mock
+
+
+@pytest.fixture
+def trigger_event(mocker):
+    trigger_event_mock = AsyncMock(return_value='my response')
+    mocker.patch('async_receive.trigger_event', new=trigger_event_mock)
+    return trigger_event_mock
+
+
+def test_message(send_to_client, trigger_event):
+    _run(receive('MESSAGE', 'data'))
+    trigger_event.mock.assert_called_once_with('message', 'data')
+    send_to_client.mock.assert_called_once_with('MESSAGE', 'my response')
 
 
 if __name__ == '__main__':

--- a/test_async_receive.py
+++ b/test_async_receive.py
@@ -34,10 +34,11 @@ class TestReceive(unittest.TestCase):
     @mock.patch('async_receive.trigger_event',
                 new=AsyncMock(return_value='my response'))
     def test_message(self):
-        _run(receive('MESSAGE', 'data'))
-        from async_receive import send_to_client, trigger_event
-        trigger_event.mock.assert_called_once_with('message', 'data')
-        send_to_client.mock.assert_called_once_with('MESSAGE', 'my response')
+        with mock.patch('async_receive.send_to_client', new=AsyncMock()) as send_to_client:
+            with mock.patch('async_receive.trigger_event', new=AsyncMock(return_value='my response')) as trigger_event:
+                _run(receive('MESSAGE', 'data'))
+                trigger_event.mock.assert_called_once_with('message', 'data')
+                send_to_client.mock.assert_called_once_with('MESSAGE', 'my response')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have used pytest and fixtures made code cleaner, separating setup from test themselves. Just done that for the most complex tests but could be reproduced to entire code base. Downside is having to install lib from outside std lib. There is no free lunch ;)

Test results:

```console
(.venv) asyncio-testing $ pytest test_async_receive.py -k 'test_message'
================================================= test session starts =================================================
platform darwin -- Python 3.6.1, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/renzo/PycharmProjects/asyncio-testing, inifile:
plugins: mock-1.6.0
collected 3 items 

test_async_receive.py .

================================================= 2 tests deselected ==================================================
======================================= 1 passed, 2 deselected in 0.06 seconds ========================================
(.venv) asyncio-testing $ 
```